### PR TITLE
Fix up y1 and y2 value on web page

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,15 +10,17 @@ sess = tf.Session()
 
 # restore trained data
 with tf.variable_scope("regression"):
-    y1, variables = model.regression(x)
-saver = tf.train.Saver(variables)
+    logits1, variables1 = model.regression(x)
+    y1 = tf.nn.softmax(logits1)
+saver = tf.train.Saver(variables1)
 saver.restore(sess, "mnist/data/regression.ckpt")
 
 
 with tf.variable_scope("convolutional"):
     keep_prob = tf.placeholder("float")
-    y2, variables = model.convolutional(x, keep_prob)
-saver = tf.train.Saver(variables)
+    logits2, variables2 = model.convolutional(x, keep_prob)
+    y2 = tf.nn.softmax(logits2)
+saver = tf.train.Saver(variables2)
 saver.restore(sess, "mnist/data/convolutional.ckpt")
 
 


### PR DESCRIPTION
 Update y1 and y2 with earlier changes in mnist/model.py

softmax() is needed to get final y1 and y2 from logit1 and logit2.
Following up with commit 4e84b14e959ba112427759f22b7470c42947f140
And using newest re-trained model data at commit b1a45946431bd9afd86e2d23cb0b429bf08860a3